### PR TITLE
Helper functions for spherical dielectric screening

### DIFF
--- a/Helper.jl
+++ b/Helper.jl
@@ -1,0 +1,52 @@
+# This file contains the helper/utility functions
+
+# ------------------------------------------
+
+"""
+Screening factor for a dielectric sphere inside a dielectric medium
+```julia
+julia> spherical_screening_factor(1.2, 5.1)
+```
+## INPUT
+`eps_out`: dielectric constant of the external medium
+`eps_in`: dielectric constant of the inner material
+"""
+function spherical_screening_factor(eps_out, eps_in)
+  return 3.0 / (2.0 + eps_in/eps_out)
+end
+
+
+"""
+Ratio of the screening factors when the dielectric constant of the external medium is changed
+```julia
+julia> spherical_screening_factor(1.2, 2.0, 5.1)
+```
+## INPUT
+`eps_o1`: dielectric constant of the first external medium
+`eps_o2`: dielectric constant of the second external medium
+`eps_in`: dielectric constant of the inner material
+"""
+function rate_ratio_spherical_by_varying_external_dielectric(eps_o1, eps_o2, eps_in)
+  f_eps_1 = spherical_screening_factor(eps_o1, eps_in)
+  f_eps_2 = spherical_screening_factor(eps_o2, eps_in)
+  return sqrt(eps_o1/eps_o2) * (f_eps_1/f_eps_2)^2
+end
+
+
+"""
+Ratio of the screening factors when the dielectric constant of the external medium is changed
+```julia
+julia> spherical_screening_factor(1.2, 4.5, 5.0)
+```
+## INPUT
+`eps_out`: dielectric constant of the external medium
+`eps_i1`: dielectric constant of the first inner material
+`eps_i2`: dielectric constant of the second inner material
+"""
+function rate_ratio_spherical_by_varying_inner_dielectric(eps_out, eps_i1, eps_i2)
+  f_eps_1 = spherical_screening_factor(eps_out, eps_i1)
+  f_eps_2 = spherical_screening_factor(eps_out, eps_i2)
+  return (f_eps_1/f_eps_2)^2
+end
+
+# ------------------------------------------------------------------------------------

--- a/test/dielectric/screening_helper.jl
+++ b/test/dielectric/screening_helper.jl
@@ -1,0 +1,48 @@
+using Test
+
+include("../../Helper.jl")
+
+function test_spherical_screening_factor()
+  eps_in = 2.0
+  eps_out = eps_in
+  @test spherical_screening_factor(eps_out, eps_in) == 1.0
+
+  eps_in = 4.0
+  eps_out = 1.0
+  @test spherical_screening_factor(eps_out, eps_in) == 0.5
+end
+
+function test_rate_ratio_by_varying_external_dielectric()
+  eps_in = 4.0
+  eps_out1 = 2.0
+  eps_out2 = eps_out1
+  @test rate_ratio_spherical_by_varying_external_dielectric(eps_out1, eps_out2, eps_in) == 1.0
+
+  eps_in = 4.0
+  eps_out1 = 4.0
+  eps_out2 = 1.0
+  @test rate_ratio_spherical_by_varying_external_dielectric(eps_out1, eps_out2, eps_in) == 8.0
+
+  eps_in = 6.0
+  eps_out1 = 3.0
+  eps_out2 = 1.5
+  @test rate_ratio_spherical_by_varying_external_dielectric(eps_out1, eps_out2, eps_in) == sqrt(2)*1.5^2
+end
+
+function test_rate_ratio_by_varying_inner_dielectric()
+  eps_in1 = 5.0
+  eps_in2 = eps_in1
+  eps_out = 1.5
+  @test rate_ratio_spherical_by_varying_inner_dielectric(eps_out, eps_in1, eps_in2) == 1.0
+
+  eps_in1 = 6.0
+  eps_in2 = 3.0
+  eps_out = 1.5
+  @test rate_ratio_spherical_by_varying_inner_dielectric(eps_out, eps_in1, eps_in2) == (2.0/3.0)^2
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+  test_spherical_screening_factor()
+  test_rate_ratio_by_varying_external_dielectric()
+  test_rate_ratio_by_varying_inner_dielectric()
+end


### PR DESCRIPTION
Three simple functions to calculate dielectric screening factor and ratio of radiative rates when varying dielectric constant of inner or external medium.

Test cases were created to check the function output in simple cases.